### PR TITLE
fix(types): [`WatchOptions`] same-directory import statements

### DIFF
--- a/src/types/__tests__/watch-options.spec-d.ts
+++ b/src/types/__tests__/watch-options.spec-d.ts
@@ -8,8 +8,10 @@ import type {
   WatchDirectoryKind,
   WatchFileKind
 } from '#src/enums'
-import type { PollingWatch, WatchDirectory, WatchFile } from '#src/types'
 import type { JsonObject, KeysRequired } from '@flex-development/tutils'
+import type PollingWatch from '../polling-watch'
+import type WatchDirectory from '../watch-directory'
+import type WatchFile from '../watch-file'
 import type TestSubject from '../watch-options'
 
 describe('unit:interfaces/WatchOptions', () => {

--- a/src/types/watch-options.ts
+++ b/src/types/watch-options.ts
@@ -8,7 +8,9 @@ import type {
   WatchDirectoryKind,
   WatchFileKind
 } from '#src/enums'
-import type { PollingWatch, WatchDirectory, WatchFile } from '#src/types'
+import type PollingWatch from './polling-watch'
+import type WatchDirectory from './watch-directory'
+import type WatchFile from './watch-file'
 
 /**
  * File and directory watching options.


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

Fixes same-directory import statements in [`WatchOptions`][2].

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn typecheck`

```zsh
 RUN  v0.25.3

 ✓ src/enums/__tests__/imports-not-used-kind.spec-d.ts (4)
   ✓ unit:enums/ImportsNotUsedKind (4)
     ✓ should have members match Lowercase<ImportsNotUsedAsValues>
     ✓ should match [Error = "error"]
     ✓ should match [Preserve = "preserve"]
     ✓ should match [Remove = "remove"]
 ✓ src/enums/__tests__/jsx-emit.spec-d.ts (6)
   ✓ unit:enums/JsxEmit (6)
     ✓ should have members match Lowercase<Jsx>
     ✓ should match [Preserve = "preserve"]
     ✓ should match [React = "react"]
     ✓ should match [ReactJSX = "react-jsx"]
     ✓ should match [ReactJSXDev = "react-jsxdev"]
     ✓ should match [ReactNative = "react-native"]
 ✓ src/enums/__tests__/module-detection-kind.spec-d.ts (4)
   ✓ unit:enums/ModuleDetectionKind (4)
     ✓ should have members match Lowercase<ModuleDetection>
     ✓ should match [Auto = "auto"]
     ✓ should match [Force = "force"]
     ✓ should match [Legacy = "legacy"]
 ✓ src/enums/__tests__/module-kind.spec-d.ts (13)
   ✓ unit:enums/ModuleKind (13)
     ✓ should have members match Lowercase<Module>
     ✓ should match [AMD = "amd"]
     ✓ should match [CommonJS = "commonjs"]
     ✓ should match [ES6 = "es6"]
     ✓ should match [ES2015 = "es2015"]
     ✓ should match [ES2020 = "es2020"]
     ✓ should match [ES2022 = "es2022"]
     ✓ should match [ESNext = "esnext"]
     ✓ should match [Node16 = "node16"]
     ✓ should match [NodeNext = "nodenext"]
     ✓ should match [None = "none"]
     ✓ should match [System = "system"]
     ✓ should match [UMD = "umd"]
 ✓ src/enums/__tests__/module-resolution-kind.spec-d.ts (5)
   ✓ unit:enums/ModuleResolutionKind (5)
     ✓ should have members match Lowercase<ModuleResolution>
     ✓ should match [Classic = "classic"]
     ✓ should match [NodeJs = "node"]
     ✓ should match [Node16 = "node16"]
     ✓ should match [NodeNext = "nodenext"]
 ✓ src/enums/__tests__/new-line-kind.spec-d.ts (3)
   ✓ unit:enums/NewLineKind (3)
     ✓ should have members match Lowercase<NewLine>
     ✓ should match [CarriageReturnLineFeed = "crlf"]
     ✓ should match [LineFeed = "lf"]
 ✓ src/enums/__tests__/polling-watch-kind.spec-d.ts (6)
   ✓ unit:enums/PollingWatchKind (6)
     ✓ should have members match Exclude<PollingWatch, Lowercase<string>>
     ✓ should match [DynamicPriority = "dynamicPriorityPolling"]
     ✓ should match [FixedChunkSize = "fixedChunkSize"]
     ✓ should match [FixedInterval = "fixedPollingInterval"]
     ✓ should match [PriorityInterval = "priorityPollingInterval"]
     ✓ should match [SynchronousWatchDirectory = "synchronousWatchDirectory"]
 ✓ src/enums/__tests__/script-target.spec-d.ts (13)
   ✓ unit:enums/ScriptTarget (13)
     ✓ should have members match Lowercase<Target>
     ✓ should match [ES3 = "es3"]
     ✓ should match [ES5 = "es5"]
     ✓ should match [ES6 = "es6"]
     ✓ should match [ES2015 = "es2015"]
     ✓ should match [ES2016 = "es2016"]
     ✓ should match [ES2017 = "es2017"]
     ✓ should match [ES2018 = "es2018"]
     ✓ should match [ES2019 = "es2019"]
     ✓ should match [ES2020 = "es2020"]
     ✓ should match [ES2021 = "es2021"]
     ✓ should match [ES2022 = "es2022"]
     ✓ should match [ESNext = "esnext"]
 ✓ src/enums/__tests__/watch-directory-kind.spec-d.ts (5)
   ✓ unit:enums/WatchDirectoryKind (5)
     ✓ should have members match Lowercase<WatchDirectory>
     ✓ should match [DynamicPriorityPolling = "dynamicprioritypolling"]
     ✓ should match [FixedChunkSizePolling = "fixedchunksizepolling"]
     ✓ should match [FixedPollingInterval = "fixedpollinginterval"]
     ✓ should match [UseFsEvents = "usefsevents"]
 ✓ src/enums/__tests__/watch-file-kind.spec-d.ts (7)
   ✓ unit:enums/WatchFileKind (7)
     ✓ should have members match Lowercase<WatchFile>
     ✓ should match [DynamicPriorityPolling = "dynamicprioritypolling"]
     ✓ should match [FixedChunkSizePolling = "fixedchunksizepolling"]
     ✓ should match [FixedPollingInterval = "fixedpollinginterval"]
     ✓ should match [PriorityPollingInterval = "prioritypollinginterval"]
     ✓ should match [UseFsEvents = "usefsevents"]
     ✓ should match [UseFsEventsOnParentDirectory = "usefseventsonparentdirectory"]
 ✓ src/interfaces/__tests__/plugin.spec-d.ts (3)
   ✓ unit:interfaces/Plugin (3)
     ✓ should allow empty object
     ✓ should be json object
     ✓ should match [name?: string]
 ✓ src/interfaces/__tests__/tsconfig.spec-d.ts (13)
   ✓ unit:interfaces/TSConfig (13)
     ✓ should allow empty object
     ✓ should be json object
     ✓ should match [buildOptions?: BuildOptions]
     ✓ should match [compileOnSave?: boolean]
     ✓ should match [compilerOptions?: CompilerOptions]
     ✓ should match [exclude?: string[]]
     ✓ should match [extends?: string]
     ✓ should match [files?: string[]]
     ✓ should match [include?: string[]]
     ✓ should match [references?: ProjectReference[]]
     ✓ should match [ts-node?: TsNodeOptions]
     ✓ should match [typeAcquisition?: TypeAcquisition]
     ✓ should match [watchOptions?: WatchOptions]
 ✓ src/types/__tests__/build-options.spec-d.ts (8)
   ✓ unit:types/BuildOptions (8)
     ✓ should allow empty object
     ✓ should be json object
     ✓ should match [assumeChangesOnlyAffectDirectDependencies?: boolean]
     ✓ should match [dry?: boolean]
     ✓ should match [force?: boolean]
     ✓ should match [incremental?: boolean]
     ✓ should match [traceResolution?: boolean]
     ✓ should match [verbose?: boolean]
 ✓ src/types/__tests__/compiler-options-value.spec-d.ts (10)
   ✓ unit:types/CompilerOptionsValue (10)
     ✓ should be json value
     ✓ should extract (number | string)[]
     ✓ should extract MapLike<string[]>
     ✓ should extract Plugin[]
     ✓ should extract ProjectReference[]
     ✓ should extract boolean
     ✓ should extract number
     ✓ should extract string
     ✓ should extract string[]
     ✓ should extract null
 ✓ src/types/__tests__/compiler-options.spec-d.ts (109)
   ✓ unit:interfaces/CompilerOptions (109)
     ✓ should allow empty object
     ✓ should be json object
     ✓ should match [allowJs?: boolean]
     ✓ should match [allowSyntheticDefaultImports?: boolean]
     ✓ should match [allowUmdGlobalAccess?: boolean]
     ✓ should match [allowUnreachableCode?: boolean]
     ✓ should match [allowUnusedLabels?: boolean]
     ✓ should match [alwaysStrict?: boolean]
     ✓ should match [assumeChangesOnlyAffectDirectDependencies?: boolean]
     ✓ should match [baseUrl?: LiteralUnion<"." | "./", string>]
     ✓ should match [charset?: string]
     ✓ should match [checkJs?: boolean]
     ✓ should match [composite?: boolean]
     ✓ should match [declaration?: boolean]
     ✓ should match [declarationDir?: string]
     ✓ should match [declarationMap?: boolean]
     ✓ should match [diagnostics?: boolean]
     ✓ should match [disableReferencedProjectLoad?: boolean]
     ✓ should match [disableSizeLimit?: boolean]
     ✓ should match [disableSolutionSearching?: boolean]
     ✓ should match [disableSourceOfProjectReferenceRedirect?: boolean]
     ✓ should match [downlevelIteration?: boolean]
     ✓ should match [emitBOM?: boolean]
     ✓ should match [emitDeclarationOnly?: boolean]
     ✓ should match [emitDecoratorMetadata?: boolean]
     ✓ should match [esModuleInterop?: boolean]
     ✓ should match [exactOptionalPropertyTypes?: boolean]
     ✓ should match [experimentalDecorators?: boolean]
     ✓ should match [explainFiles?: boolean]
     ✓ should match [extendedDiagnostics?: boolean]
     ✓ should match [fallbackPolling?: FallbackPolling]
     ✓ should match [forceConsistentCasingInFileNames?: boolean]
     ✓ should match [generateCpuProfile?: LiteralUnion<"profile.cpuprofile", string>]
     ✓ should match [importHelpers?: boolean]
     ✓ should match [importsNotUsedAsValues?: ImportsNotUsedAsValues | ImportsNotUsedKind]
     ✓ should match [incremental?: boolean]
     ✓ should match [inlineSourceMap?: boolean]
     ✓ should match [inlineSources?: boolean]
     ✓ should match [isolatedModules?: boolean]
     ✓ should match [jsx?: Jsx | JsxEmit]
     ✓ should match [jsxFactory?: LiteralUnion<"h" | "React.createElement", string>]
     ✓ should match [jsxFragmentFactory?: LiteralUnion<"Fragment" | "React.Fragment", string>]
     ✓ should match [jsxImportSource?: LiteralUnion<"react", string>]
     ✓ should match [keyofStringsOnly?: boolean]
     ✓ should match [lib?: Lib[]]
     ✓ should match [listEmittedFiles?: boolean]
     ✓ should match [listFiles?: boolean]
     ✓ should match [listFilesOnly?: boolean]
     ✓ should match [mapRoot?: string]
     ✓ should match [maxNodeModuleJsDepth?: number]
     ✓ should match [module?: Module | ModuleKind]
     ✓ should match [moduleDetection?: ModuleDetection | ModuleDetectionKind]
     ✓ should match [moduleResolution?: ModuleResolution | ModuleResolutionKind]
     ✓ should match [moduleSuffixes?: string[]]
     ✓ should match [newLine?: NewLine | NewLineKind]
     ✓ should match [noEmit?: boolean]
     ✓ should match [noEmitHelpers?: boolean]
     ✓ should match [noEmitOnError?: boolean]
     ✓ should match [noErrorTruncation?: boolean]
     ✓ should match [noFallthroughCasesInSwitch?: boolean]
     ✓ should match [noImplicitAny?: boolean]
     ✓ should match [noImplicitOverride?: boolean]
     ✓ should match [noImplicitReturns?: boolean]
     ✓ should match [noImplicitThis?: boolean]
     ✓ should match [noImplicitUseStrict?: boolean]
     ✓ should match [noLib?: boolean]
     ✓ should match [noPropertyAccessFromIndexSignature?: boolean]
     ✓ should match [noResolve?: boolean]
     ✓ should match [noStrictGenericChecks?: boolean]
     ✓ should match [noUncheckedIndexedAccess?: boolean]
     ✓ should match [noUnusedLocals?: boolean]
     ✓ should match [noUnusedParameters?: boolean]
     ✓ should match [out?: string]
     ✓ should match [outDir?: string]
     ✓ should match [outFile?: string]
     ✓ should match [paths?: Paths]
     ✓ should match [plugins?: Plugin[]]
     ✓ should match [preserveConstEnums?: boolean]
     ✓ should match [preserveSymlinks?: boolean]
     ✓ should match [preserveValueImports?: boolean]
     ✓ should match [preserveWatchOutput?: boolean]
     ✓ should match [pretty?: boolean]
     ✓ should match [reactNamespace?: LiteralUnion<"React", string>]
     ✓ should match [removeComments?: boolean]
     ✓ should match [resolveJsonModule?: boolean]
     ✓ should match [rootDir?: LiteralUnion<"." | "./", string>]
     ✓ should match [rootDirs?: string[]]
     ✓ should match [skipDefaultLibCheck?: boolean]
     ✓ should match [skipLibCheck?: boolean]
     ✓ should match [sourceMap?: boolean]
     ✓ should match [sourceRoot?: string]
     ✓ should match [strict?: boolean]
     ✓ should match [strictBindCallApply?: boolean]
     ✓ should match [strictFunctionTypes?: boolean]
     ✓ should match [strictNullChecks?: boolean]
     ✓ should match [strictPropertyInitialization?: boolean]
     ✓ should match [stripInternal?: boolean]
     ✓ should match [suppressExcessPropertyErrors?: boolean]
     ✓ should match [suppressImplicitAnyIndexErrors?: boolean]
     ✓ should match [target?: ScriptTarget | Target]
     ✓ should match [traceResolution?: boolean]
     ✓ should match [tsBuildInfoFile?: LiteralUnion<".tsbuildinfo", string>]
     ✓ should match [typeRoots?: string[]]
     ✓ should match [types?: string[]]
     ✓ should match [useDefineForClassFields?: boolean]
     ✓ should match [useUnknownInCatchVariables?: boolean]
     ✓ should match [watch?: boolean]
     ✓ should match [watchDirectory?: WatchDirectory | WatchDirectoryKind]
     ✓ should match [watchFile?: WatchFile | WatchFileKind]
 ✓ src/types/__tests__/fallback-polling.spec-d.ts (9)
   ✓ unit:types/FallbackPolling (9)
     ✓ should be json value
     ✓ should extract "dynamicPriorityPolling"
     ✓ should extract "fixedChunkSize"
     ✓ should extract "fixedPollingInterval"
     ✓ should extract "priorityPollingInterval"
     ✓ lowercase (4)
       ✓ should extract "dynamicpriority"
       ✓ should extract "fixedchunksize"
       ✓ should extract "fixedinterval"
       ✓ should extract "priorityinterval"
 ✓ src/types/__tests__/imports-not-used-as-values.spec-d.ts (4)
   ✓ unit:types/ImportsNotUsedAsValues (4)
     ✓ should be json value
     ✓ should extract "error"
     ✓ should extract "preserve"
     ✓ should extract "remove"
 ✓ src/types/__tests__/jsx.spec-d.ts (6)
   ✓ unit:types/Jsx (6)
     ✓ should be json value
     ✓ should extract "preserve"
     ✓ should extract "react-jsx"
     ✓ should extract "react-jsxdev"
     ✓ should extract "react-native"
     ✓ should extract "react"
 ✓ src/types/__tests__/lib.spec-d.ts (117)
   ✓ unit:types/Lib (117)
     ✓ should be json value
     ✓ should extract "DOM.Iterable"
     ✓ should extract "DOM"
     ✓ should extract "ES5"
     ✓ should extract "ES6"
     ✓ should extract "ES7"
     ✓ should extract "ES2015.Collection"
     ✓ should extract "ES2015.Core"
     ✓ should extract "ES2015.Generator"
     ✓ should extract "ES2015.Iterable"
     ✓ should extract "ES2015.Promise"
     ✓ should extract "ES2015.Proxy"
     ✓ should extract "ES2015.Reflect"
     ✓ should extract "ES2015.Symbol.WellKnown"
     ✓ should extract "ES2015.Symbol"
     ✓ should extract "ES2015"
     ✓ should extract "ES2016.Array.Include"
     ✓ should extract "ES2016"
     ✓ should extract "ES2017.Intl"
     ✓ should extract "ES2017.Object"
     ✓ should extract "ES2017.SharedMemory"
     ✓ should extract "ES2017.String"
     ✓ should extract "ES2017.TypedArrays"
     ✓ should extract "ES2017"
     ✓ should extract "ES2018.AsyncGenerator"
     ✓ should extract "ES2018.AsyncIterable"
     ✓ should extract "ES2018.Intl"
     ✓ should extract "ES2018.Promise"
     ✓ should extract "ES2018.Regexp"
     ✓ should extract "ES2018"
     ✓ should extract "ES2019.Array"
     ✓ should extract "ES2019.Object"
     ✓ should extract "ES2019.String"
     ✓ should extract "ES2019.Symbol"
     ✓ should extract "ES2019"
     ✓ should extract "ES2020.BigInt"
     ✓ should extract "ES2020.Intl"
     ✓ should extract "ES2020.Promise"
     ✓ should extract "ES2020.SharedMemory"
     ✓ should extract "ES2020.String"
     ✓ should extract "ES2020.Symbol.WellKnown"
     ✓ should extract "ES2020"
     ✓ should extract "ES2021.Promise"
     ✓ should extract "ES2021.String"
     ✓ should extract "ES2021.WeakRef"
     ✓ should extract "ES2021"
     ✓ should extract "ESNext.Array"
     ✓ should extract "ESNext.AsyncIterable"
     ✓ should extract "ESNext.BigInt"
     ✓ should extract "ESNext.Intl"
     ✓ should extract "ESNext.Promise"
     ✓ should extract "ESNext.String"
     ✓ should extract "ESNext.Symbol"
     ✓ should extract "ESNext.WeakRef"
     ✓ should extract "ESNext"
     ✓ should extract "ScriptHost"
     ✓ should extract "WebWorker.ImportScripts"
     ✓ should extract "WebWorker.Iterable"
     ✓ should extract "WebWorker"
     ✓ lowercase (58)
       ✓ should extract "dom.iterable"
       ✓ should extract "dom"
       ✓ should extract "es5"
       ✓ should extract "es6"
       ✓ should extract "es7"
       ✓ should extract "es2015.collection"
       ✓ should extract "es2015.core"
       ✓ should extract "es2015.generator"
       ✓ should extract "es2015.iterable"
       ✓ should extract "es2015.promise"
       ✓ should extract "es2015.proxy"
       ✓ should extract "es2015.reflect"
       ✓ should extract "es2015.symbol.wellknown"
       ✓ should extract "es2015.symbol"
       ✓ should extract "es2015"
       ✓ should extract "es2016.array.include"
       ✓ should extract "es2016"
       ✓ should extract "es2017.intl"
       ✓ should extract "es2017.object"
       ✓ should extract "es2017.sharedmemory"
       ✓ should extract "es2017.string"
       ✓ should extract "es2017.typedarrays"
       ✓ should extract "es2017"
       ✓ should extract "es2018.asyncgenerator"
       ✓ should extract "es2018.asynciterable"
       ✓ should extract "es2018.intl"
       ✓ should extract "es2018.promise"
       ✓ should extract "es2018.regexp"
       ✓ should extract "es2018"
       ✓ should extract "es2019.array"
       ✓ should extract "es2019.object"
       ✓ should extract "es2019.string"
       ✓ should extract "es2019.symbol"
       ✓ should extract "es2019"
       ✓ should extract "es2020.bigint"
       ✓ should extract "es2020.intl"
       ✓ should extract "es2020.promise"
       ✓ should extract "es2020.sharedmemory"
       ✓ should extract "es2020.string"
       ✓ should extract "es2020.symbol.wellknown"
       ✓ should extract "es2020"
       ✓ should extract "es2021.promise"
       ✓ should extract "es2021.string"
       ✓ should extract "es2021.weakref"
       ✓ should extract "es2021"
       ✓ should extract "esnext.array"
       ✓ should extract "esnext.asynciterable"
       ✓ should extract "esnext.bigint"
       ✓ should extract "esnext.intl"
       ✓ should extract "esnext.promise"
       ✓ should extract "esnext.string"
       ✓ should extract "esnext.symbol"
       ✓ should extract "esnext.weakref"
       ✓ should extract "esnext"
       ✓ should extract "scripthost"
       ✓ should extract "webworker.importscripts"
       ✓ should extract "webworker.iterable"
       ✓ should extract "webworker"
 ✓ src/types/__tests__/module-detection.spec-d.ts (4)
   ✓ unit:types/ModuleDetection (4)
     ✓ should be json value
     ✓ should extract "auto"
     ✓ should extract "force"
     ✓ should extract "legacy"
 ✓ src/types/__tests__/module-resolution.spec-d.ts (9)
   ✓ unit:types/ModuleResolution (9)
     ✓ should be json value
     ✓ should extract "Classic"
     ✓ should extract "Node"
     ✓ should extract "Node16"
     ✓ should extract "NodeNext"
     ✓ lowercase (4)
       ✓ should extract "classic"
       ✓ should extract "node"
       ✓ should extract "node16"
       ✓ should extract "nodenext"
 ✓ src/types/__tests__/module.spec-d.ts (25)
   ✓ unit:types/Module (25)
     ✓ should be json value
     ✓ should extract "AMD"
     ✓ should extract "CommonJS"
     ✓ should extract "ES6"
     ✓ should extract "ES2015"
     ✓ should extract "ES2020"
     ✓ should extract "ES2022"
     ✓ should extract "ESNext"
     ✓ should extract "Node16"
     ✓ should extract "NodeNext"
     ✓ should extract "None"
     ✓ should extract "System"
     ✓ should extract "UMD"
     ✓ lowercase (12)
       ✓ should extract "amd"
       ✓ should extract "commonjs"
       ✓ should extract "es6"
       ✓ should extract "es2015"
       ✓ should extract "es2020"
       ✓ should extract "es2022"
       ✓ should extract "esnext"
       ✓ should extract "node16"
       ✓ should extract "nodenext"
       ✓ should extract "none"
       ✓ should extract "system"
       ✓ should extract "umd"
 ✓ src/types/__tests__/new-line.spec-d.ts (5)
   ✓ unit:types/NewLine (5)
     ✓ should be json value
     ✓ should extract "CRLF"
     ✓ should extract "LF"
     ✓ lowercase (2)
       ✓ should extract "crlf"
       ✓ should extract "lf"
 ✓ src/types/__tests__/paths.spec-d.ts (3)
   ✓ unit:types/Paths (3)
     ✓ should allow empty object
     ✓ should be json object
     ✓ should only have string[] values
 ✓ src/types/__tests__/polling-watch.spec-d.ts (10)
   ✓ unit:types/PollingWatch (10)
     ✓ should be json value
     ✓ should extract "dynamicPriorityPolling"
     ✓ should extract "fixedChunkSize"
     ✓ should extract "fixedPollingInterval"
     ✓ should extract "priorityPollingInterval"
     ✓ should extract "synchronousWatchDirectory"
     ✓ lowercase (4)
       ✓ should extract "dynamicpriority"
       ✓ should extract "fixedchunksize"
       ✓ should extract "fixedinterval"
       ✓ should extract "priorityinterval"
 ✓ src/types/__tests__/project-reference.spec-d.ts (5)
   ✓ unit:interfaces/ProjectReference (5)
     ✓ should be json object
     ✓ should match [circular?: boolean]
     ✓ should match [originalPath?: string]
     ✓ should match [path: string]
     ✓ should match [prepend?: boolean]
 ✓ src/types/__tests__/target.spec-d.ts (25)
   ✓ unit:types/Target (25)
     ✓ should be json value
     ✓ should extract "ES3"
     ✓ should extract "ES5"
     ✓ should extract "ES6"
     ✓ should extract "ES2015"
     ✓ should extract "ES2016"
     ✓ should extract "ES2017"
     ✓ should extract "ES2018"
     ✓ should extract "ES2019"
     ✓ should extract "ES2020"
     ✓ should extract "ES2021"
     ✓ should extract "ES2022"
     ✓ should extract "ESNext"
     ✓ lowercase (12)
       ✓ should extract "es3"
       ✓ should extract "es5"
       ✓ should extract "es6"
       ✓ should extract "es2015"
       ✓ should extract "es2016"
       ✓ should extract "es2017"
       ✓ should extract "es2018"
       ✓ should extract "es2019"
       ✓ should extract "es2020"
       ✓ should extract "es2021"
       ✓ should extract "es2022"
       ✓ should extract "esnext"
 ✓ src/types/__tests__/ts-node-options.spec-d.ts (2)
   ✓ unit:interfaces/TsNodeOptions (2)
     ✓ should be json object
     ✓ should match ts-node options
 ✓ src/types/__tests__/type-acquisition.spec-d.ts (7)
   ✓ unit:interfaces/TypeAcquisition (7)
     ✓ should allow empty object
     ✓ should be json object
     ✓ should match [disableFilenameBasedTypeAcquisition?: boolean]
     ✓ should match [enable?: boolean]
     ✓ should match [enableAutoDiscovery?: boolean]
     ✓ should match [exclude?: string[]]
     ✓ should match [include?: string[]]
 ✓ src/types/__tests__/watch-directory.spec-d.ts (9)
   ✓ unit:types/WatchDirectory (9)
     ✓ should be json value
     ✓ should extract "dynamicPriorityPolling"
     ✓ should extract "fixedChunkSizePolling"
     ✓ should extract "fixedPollingInterval"
     ✓ should extract "useFsEvents"
     ✓ lowercase (4)
       ✓ should extract "dynamicprioritypolling"
       ✓ should extract "fixedchunksizepolling"
       ✓ should extract "fixedpollinginterval"
       ✓ should extract "usefsevents"
 ✓ src/types/__tests__/watch-file.spec-d.ts (12)
   ✓ unit:types/WatchFile (12)
     ✓ should be json value
     ✓ should extract "dynamicPriorityPolling"
     ✓ should extract "fixedChunkSizePolling"
     ✓ should extract "fixedPollingInterval"
     ✓ should extract "priorityPollingInterval"
     ✓ should extract "useFsEvents"
     ✓ should extract "useFsEventsOnParentDirectory"
     ✓ lowercase (5)
       ✓ should extract "dynamicprioritypolling"
       ✓ should extract "fixedchunksizepolling"
       ✓ should extract "fixedpollinginterval"
       ✓ should extract "usefsevents"
       ✓ should extract "usefseventsonparentdirectory"
 ✓ src/types/__tests__/watch-options.spec-d.ts (8)
   ✓ unit:interfaces/WatchOptions (8)
     ✓ should allow empty object
     ✓ should be json object
     ✓ should match [excludeDirectories?: string[]]
     ✓ should match [excludeFiles?: string[]]
     ✓ should match [fallbackPolling?: PollingWatch | PollingWatchKind]
     ✓ should match [synchronousWatchDirectory?: boolean]
     ✓ should match [watchDirectory?: WatchDirectory | WatchDirectoryKind]
     ✓ should match [watchFile?: WatchFile | WatchFileKind]

 Test Files  32 passed (32)
      Tests  469 passed (469)
Type Errors  no errors
   Start at  15:13:32
   Duration  1.68s
```

### `yarn build`

```zsh
ℹ Building @flex-development/tsconfig-types                                                         15:19:17
✔ Build succeeded for @flex-development/tsconfig-types                                              15:19:19
  dist (total size: 12.9 kB)                                                                        15:19:19
  └─ dist/index.mjs (80 B)
  └─ dist/index.d.mts (143 B)
  └─ dist/enums/imports-not-used-kind.mjs (374 B)
  └─ dist/enums/imports-not-used-kind.d.mts (398 B)
  └─ dist/enums/index.mjs (901 B)
  └─ dist/enums/index.d.mts (715 B)
  └─ dist/enums/jsx-emit.mjs (353 B)
  └─ dist/enums/jsx-emit.d.mts (421 B)
  └─ dist/enums/module-detection-kind.mjs (374 B)
  └─ dist/enums/module-detection-kind.d.mts (380 B)
  └─ dist/enums/module-kind.mjs (598 B)
  └─ dist/enums/module-kind.d.mts (512 B)
  └─ dist/enums/module-resolution-kind.mjs (440 B)
  └─ dist/enums/module-resolution-kind.d.mts (420 B)
  └─ dist/enums/new-line-kind.mjs (275 B)
  └─ dist/enums/new-line-kind.d.mts (351 B)
  └─ dist/enums/polling-watch-kind.mjs (561 B)
  └─ dist/enums/polling-watch-kind.d.mts (661 B)
  └─ dist/enums/script-target.mjs (632 B)
  └─ dist/enums/script-target.d.mts (520 B)
  └─ dist/enums/watch-directory-kind.mjs (514 B)
  └─ dist/enums/watch-directory-kind.d.mts (511 B)
  └─ dist/enums/watch-file-kind.mjs (615 B)
  └─ dist/enums/watch-file-kind.d.mts (600 B)
  └─ dist/interfaces/index.mjs (0 B)
  └─ dist/interfaces/index.d.mts (185 B)
  └─ dist/types/index.mjs (0 B)
  └─ dist/types/index.d.mts (1.35 kB)
  dist (total size: 38.9 kB)                                                                        15:19:19
  └─ dist/interfaces/index.d.mts (185 B)
  └─ dist/interfaces/plugin.d.mts (394 B)
  └─ dist/interfaces/tsconfig.d.mts (1.96 kB)
  └─ dist/types/build-options.d.mts (1.08 kB)
  └─ dist/types/compiler-options-value.d.mts (572 B)
  └─ dist/types/compiler-options.d.mts (18.2 kB)
  └─ dist/types/fallback-polling.d.mts (612 B)
  └─ dist/types/imports-not-used-as-values.d.mts (342 B)
  └─ dist/types/index.d.mts (1.35 kB)
  └─ dist/types/jsx.d.mts (316 B)
  └─ dist/types/lib.d.mts (1.33 kB)
  └─ dist/types/module-detection.d.mts (303 B)
  └─ dist/types/module-resolution.d.mts (398 B)
  └─ dist/types/module.d.mts (414 B)
  └─ dist/types/new-line.d.mts (347 B)
  └─ dist/types/paths.d.mts (333 B)
  └─ dist/types/polling-watch.d.mts (464 B)
  └─ dist/types/project-reference.d.mts (949 B)
  └─ dist/types/target.d.mts (416 B)
  └─ dist/types/ts-node-options.d.mts (5.54 kB)
  └─ dist/types/type-acquisition.d.mts (892 B)
  └─ dist/types/watch-directory.d.mts (444 B)
  └─ dist/types/watch-file.d.mts (475 B)
  └─ dist/types/watch-options.d.mts (1.61 kB)
Σ Total build size: 51.8 kB                                                                         15:19:19
```

## Linked issues

<!--
A list of linked issues and/or pull requests.

- <closes|fixes|resolves> #<issue-number>
- <prereleases|releases> #<pr-number>
-->

- fixes #5

## Related documents

<!-- A list of related documents (e.g. docs, proposals, specs, etc), if any. -->

N/A

## Additional context

<!-- Include additional details here. Be sure to note if any tolerable vulnerabilities or warnings have been introduced. -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/tsconfig-types/blob/main/CONTRIBUTING.md#pull-request-titles
[2]: https://github.com/flex-development/tsconfig-types/blob/2.0.0/src/types/watch-options.ts
